### PR TITLE
Add header UI registry to extension system

### DIFF
--- a/web/src/components/Layout/MainContainer.tsx
+++ b/web/src/components/Layout/MainContainer.tsx
@@ -1,4 +1,5 @@
 import { Menu, Settings } from "lucide-react";
+import { useHeaderUIConfig } from "../../lib/registries/headerUIRegistry";
 import { ConnectionStatus } from "../ui";
 
 interface Props {
@@ -14,6 +15,22 @@ function MainContainer({
 	onOpenSettings,
 	title = "Pockode",
 }: Props) {
+	const { HeaderContent, TitleComponent } = useHeaderUIConfig();
+
+	// If custom HeaderContent is provided, use it instead
+	if (HeaderContent) {
+		return (
+			<div className="flex min-w-0 flex-1 flex-col overflow-hidden bg-th-bg-primary">
+				<HeaderContent
+					onOpenSidebar={onOpenSidebar}
+					onOpenSettings={onOpenSettings}
+					title={title}
+				/>
+				{children}
+			</div>
+		);
+	}
+
 	return (
 		<div className="flex min-w-0 flex-1 flex-col overflow-hidden bg-th-bg-primary">
 			<header className="flex h-11 shrink-0 items-center justify-between border-b border-th-border px-3 sm:h-12 sm:px-4">
@@ -28,9 +45,13 @@ function MainContainer({
 							<Menu className="h-5 w-5" aria-hidden="true" />
 						</button>
 					)}
-					<h1 className="text-base font-bold text-th-text-primary sm:text-lg">
-						{title}
-					</h1>
+					{TitleComponent ? (
+						<TitleComponent />
+					) : (
+						<h1 className="text-base font-bold text-th-text-primary sm:text-lg">
+							{title}
+						</h1>
+					)}
 				</div>
 				<div className="flex items-center gap-2">
 					<ConnectionStatus />

--- a/web/src/extensions/ExampleExtension/headerUI/CustomHeaderTitle.tsx
+++ b/web/src/extensions/ExampleExtension/headerUI/CustomHeaderTitle.tsx
@@ -1,0 +1,7 @@
+export default function CustomHeaderTitle() {
+	return (
+		<h1 className="text-base font-bold text-th-text-primary sm:text-lg">
+			Custom Title
+		</h1>
+	);
+}

--- a/web/src/extensions/ExampleExtension/index.ts
+++ b/web/src/extensions/ExampleExtension/index.ts
@@ -1,6 +1,9 @@
 import { DEFAULT_PRIORITY, type Extension } from "../../lib/extensions";
 import AboutSection from "./settings/AboutSection";
 
+// Uncomment below import to enable custom header UI
+// import CustomHeaderTitle from "./headerUI/CustomHeaderTitle";
+
 // Uncomment below import to enable custom sidebar UI
 // import CustomSidebarContent from "./sidebarUI/CustomSidebarContent";
 
@@ -20,6 +23,11 @@ export const activate: Extension["activate"] = (ctx) => {
 		priority: DEFAULT_PRIORITY + 100,
 		component: AboutSection,
 	});
+
+	// Uncomment below to enable custom header title
+	// ctx.headerUI.configure({
+	// 	TitleComponent: CustomHeaderTitle,
+	// });
 
 	// Uncomment below to enable custom sidebar UI (replaces default tabbed sidebar)
 	// ctx.sidebarUI.configure({

--- a/web/src/extensions/README.md
+++ b/web/src/extensions/README.md
@@ -80,6 +80,24 @@ ctx.chatUI.configure({
 
 See `chatUIRegistry.ts` for prop interfaces (`AvatarProps`, `InputBarProps`, etc.).
 
+### ctx.headerUI.configure()
+
+Customize the header bar by replacing the entire header or just the title.
+
+```ts
+// Replace the entire header (menu button, title, settings button, etc.)
+ctx.headerUI.configure({
+  HeaderContent: CustomHeader, // receives { onOpenSidebar, onOpenSettings, title }
+});
+
+// Or just replace the title
+ctx.headerUI.configure({
+  TitleComponent: CustomTitle, // no props - use hooks for data
+});
+```
+
+See `headerUIRegistry.ts` for prop interfaces (`HeaderContentProps`).
+
 ### ctx.sidebarUI.configure()
 
 Replace the default tabbed sidebar with a custom component.
@@ -118,4 +136,4 @@ Any directory under `extensions/` with an `index.ts` exporting `id` and `activat
 
 ## Example
 
-See `ExampleExtension/` for working examples of settings, chatUI, sidebarUI, and theme customization. Non-settings examples are commented out by default — uncomment to enable.
+See `ExampleExtension/` for working examples of settings, headerUI, chatUI, sidebarUI, and theme customization. Non-settings examples are commented out by default — uncomment to enable.

--- a/web/src/lib/extensions.test.ts
+++ b/web/src/lib/extensions.test.ts
@@ -8,6 +8,10 @@ import {
 } from "./extensions";
 import { resetChatUIConfig } from "./registries/chatUIRegistry";
 import {
+	getHeaderUIConfig,
+	resetHeaderUIConfig,
+} from "./registries/headerUIRegistry";
+import {
 	getSettingsSections,
 	resetSettingsSections,
 } from "./registries/settingsRegistry";
@@ -32,6 +36,7 @@ describe("extensions", () => {
 		}
 		resetSettingsSections();
 		resetChatUIConfig();
+		resetHeaderUIConfig();
 		resetSidebarUIConfig();
 		resetCustomThemes();
 	});
@@ -93,6 +98,23 @@ describe("extensions", () => {
 			expect(result).toBe(true);
 			expect(getSettingsSections()).toHaveLength(0);
 			expect(isExtensionLoaded("test")).toBe(false);
+		});
+
+		it("cleans up headerUI config", () => {
+			const Component = () => null;
+			loadExtension(
+				createExtension({
+					activate: (ctx) => {
+						ctx.headerUI.configure({ HeaderContent: Component });
+					},
+				}),
+			);
+
+			expect(getHeaderUIConfig().HeaderContent).toBe(Component);
+
+			unloadExtension("test");
+
+			expect(getHeaderUIConfig().HeaderContent).toBeUndefined();
 		});
 
 		it("cleans up sidebarUI config", () => {

--- a/web/src/lib/extensions.ts
+++ b/web/src/lib/extensions.ts
@@ -4,6 +4,11 @@ import {
 	setChatUIConfig,
 } from "./registries/chatUIRegistry";
 import {
+	type HeaderUIConfig,
+	resetHeaderUIConfig,
+	setHeaderUIConfig,
+} from "./registries/headerUIRegistry";
+import {
 	DEFAULT_PRIORITY,
 	registerSettingsSection,
 	type SettingsSectionConfig,
@@ -26,6 +31,9 @@ export interface ExtensionContext {
 	};
 	readonly chatUI: {
 		configure(config: Partial<ChatUIConfig>): void;
+	};
+	readonly headerUI: {
+		configure(config: Partial<HeaderUIConfig>): void;
 	};
 	readonly sidebarUI: {
 		configure(config: Partial<SidebarUIConfig>): void;
@@ -64,6 +72,12 @@ function createContext(extensionId: string): InternalContext {
 			configure(config) {
 				setChatUIConfig(config);
 				disposables.push(() => resetChatUIConfig());
+			},
+		},
+		headerUI: {
+			configure(config) {
+				setHeaderUIConfig(config);
+				disposables.push(() => resetHeaderUIConfig());
 			},
 		},
 		sidebarUI: {

--- a/web/src/lib/registries/headerUIRegistry.test.ts
+++ b/web/src/lib/registries/headerUIRegistry.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	getHeaderUIConfig,
+	resetHeaderUIConfig,
+	setHeaderUIConfig,
+} from "./headerUIRegistry";
+
+describe("headerUIRegistry", () => {
+	afterEach(() => {
+		resetHeaderUIConfig();
+	});
+
+	it("sets config values", () => {
+		const Component = () => null;
+		setHeaderUIConfig({ HeaderContent: Component });
+
+		expect(getHeaderUIConfig().HeaderContent).toBe(Component);
+	});
+
+	it("merges config with existing values", () => {
+		const Header = () => null;
+		const Title = () => null;
+		setHeaderUIConfig({ HeaderContent: Header });
+		setHeaderUIConfig({ TitleComponent: Title });
+
+		expect(getHeaderUIConfig().HeaderContent).toBe(Header);
+		expect(getHeaderUIConfig().TitleComponent).toBe(Title);
+	});
+
+	it("resets config to default", () => {
+		setHeaderUIConfig({ HeaderContent: () => null });
+		resetHeaderUIConfig();
+
+		expect(getHeaderUIConfig().HeaderContent).toBeUndefined();
+	});
+});

--- a/web/src/lib/registries/headerUIRegistry.ts
+++ b/web/src/lib/registries/headerUIRegistry.ts
@@ -1,0 +1,69 @@
+import type { ComponentType } from "react";
+import { useSyncExternalStore } from "react";
+
+export interface HeaderUIConfig {
+	/**
+	 * Custom Header component (replaces default header).
+	 * Receives onOpenSidebar, onOpenSettings, title as props.
+	 */
+	HeaderContent?: ComponentType<HeaderContentProps>;
+
+	/**
+	 * Custom Title component (replaces default h1 title).
+	 * No props - use hooks to get data.
+	 */
+	TitleComponent?: ComponentType;
+}
+
+export interface HeaderContentProps {
+	onOpenSidebar?: () => void;
+	onOpenSettings?: () => void;
+	title?: string;
+}
+
+const defaultConfig: HeaderUIConfig = {};
+
+let config: HeaderUIConfig = { ...defaultConfig };
+const listeners = new Set<() => void>();
+
+function notifyListeners(): void {
+	for (const listener of listeners) {
+		listener();
+	}
+}
+
+function subscribe(listener: () => void): () => void {
+	listeners.add(listener);
+	return () => listeners.delete(listener);
+}
+
+function getSnapshot(): HeaderUIConfig {
+	return config;
+}
+
+/**
+ * @internal Use `ctx.headerUI.configure()` from extension context instead.
+ */
+export function setHeaderUIConfig(newConfig: Partial<HeaderUIConfig>): void {
+	config = { ...config, ...newConfig };
+	notifyListeners();
+}
+
+export function useHeaderUIConfig(): HeaderUIConfig {
+	return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+/**
+ * @internal For testing only.
+ */
+export function getHeaderUIConfig(): HeaderUIConfig {
+	return config;
+}
+
+/**
+ * @internal For testing only.
+ */
+export function resetHeaderUIConfig(): void {
+	config = { ...defaultConfig };
+	notifyListeners();
+}


### PR DESCRIPTION
# Add header UI registry to extension system

## Summary

This PR adds header customization support to the existing extension system, enabling extensions to replace the entire header or just the title via `ctx.headerUI.configure()`. This implements the "Header UI" registry from the roadmap.

## What's included

- **headerUIRegistry** (`headerUIRegistry.ts`): `setHeaderUIConfig`, `useHeaderUIConfig`, `getHeaderUIConfig`, `resetHeaderUIConfig` — runtime configuration of header components via `useSyncExternalStore`
- **ExtensionContext API** (`ctx.headerUI.configure()`): Integration with the extension system, following the same pattern as settings, chatUI, sidebarUI, and theme
- **MainContainer update** (`MainContainer.tsx`): Header now uses `useHeaderUIConfig()` to support custom `HeaderContent` (full replacement) and `TitleComponent` (title-only replacement)
- **Example** (`ExampleExtension/index.ts`): Commented-out usage example for custom header title

## Key design decisions

- **Same pattern as sidebarUIRegistry**: `headerUIRegistry` follows the exact same `useSyncExternalStore` + config object pattern as `sidebarUIRegistry` and `chatUIRegistry`. Single-object config with merge-on-set and full reset on dispose.

- **Two-level customization**: Extensions can either replace the entire header (`HeaderContent`) or just the title (`TitleComponent`). `HeaderContent` is a full replacement — the default menu button, settings button, and connection status are all replaced. `TitleComponent` only swaps the `<h1>` title within the default header layout.

- **Props forwarding for HeaderContent**: `HeaderContent` receives `onOpenSidebar`, `onOpenSettings`, and `title` as props so custom headers can wire up sidebar/settings interactions without coupling to internal state.

- **Commented out by default**: The ExampleExtension's header configuration is commented out to match the pattern used by sidebarUI and chatUI examples.

## Changes

| File | Description |
|------|-------------|
| `lib/registries/headerUIRegistry.ts` | Header UI Registry (HeaderUIConfig, HeaderContentProps, set/use/get/reset) |
| `lib/registries/headerUIRegistry.test.ts` | Registry unit tests (set, merge, reset) |
| `lib/extensions.ts` | Add `ctx.headerUI.configure()` to ExtensionContext with dispose integration |
| `lib/extensions.test.ts` | HeaderUI cleanup test on extension unload |
| `components/Layout/MainContainer.tsx` | Consume `useHeaderUIConfig()` for HeaderContent and TitleComponent |
| `extensions/ExampleExtension/index.ts` | Commented-out header title customization example |
| `extensions/ExampleExtension/headerUI/CustomHeaderTitle.tsx` | Example custom title component |
| `extensions/README.md` | Document `ctx.headerUI.configure()` API |

## Roadmap update

| Registry | Purpose | Status |
|----------|---------|--------|
| Settings | Custom settings sections | ✅ Done (PR #23) |
| Chat UI | Chat interface customization | ✅ Done (PR #32) |
| Sidebar UI | Sidebar customization | ✅ Done (PR #40) |
| Theme | Custom color themes | ✅ Done (PR #28) |
| Header UI | Header customization (content replacement + title slot) | ✅ Done (this PR) |

---

<details>
<summary>日本語版</summary>

## ヘッダーUIレジストリを拡張機能システムに追加

### 概要

このPRは、既存の拡張機能システムにヘッダーカスタマイズ機能を追加し、拡張機能が `ctx.headerUI.configure()` を通じてヘッダー全体またはタイトルのみを置換できるようにします。ロードマップの「Header UI」レジストリの実装です。

### 含まれる内容

- **headerUIRegistry** (`headerUIRegistry.ts`): `setHeaderUIConfig`, `useHeaderUIConfig`, `getHeaderUIConfig`, `resetHeaderUIConfig` — `useSyncExternalStore` によるヘッダーコンポーネントのランタイム設定
- **ExtensionContext API** (`ctx.headerUI.configure()`): settings、chatUI、sidebarUI、themeと同じパターンによる拡張機能システムとの統合
- **MainContainer更新** (`MainContainer.tsx`): ヘッダーが `useHeaderUIConfig()` を使用し、カスタム `HeaderContent`（全体置換）と `TitleComponent`（タイトルのみ置換）をサポート
- **使用例** (`ExampleExtension/index.ts`): コメントアウト済みのカスタムヘッダータイトル例

### 主な設計判断

- **sidebarUIRegistryと同一パターン**: `headerUIRegistry` は `sidebarUIRegistry` および `chatUIRegistry` とまったく同じ `useSyncExternalStore` + config オブジェクトパターンに従います。マージ方式のset、dispose時のフルリセット。

- **2段階カスタマイズ**: 拡張機能はヘッダー全体（`HeaderContent`）またはタイトルのみ（`TitleComponent`）を置換できます。`HeaderContent` は完全な置換 — デフォルトのメニューボタン、設定ボタン、接続ステータスがすべて置換されます。`TitleComponent` はデフォルトヘッダーレイアウト内の `<h1>` タイトルのみを入れ替えます。

- **HeaderContentへのprops転送**: `HeaderContent` は `onOpenSidebar`、`onOpenSettings`、`title` をpropsとして受け取るため、カスタムヘッダーが内部状態に結合することなくサイドバー/設定操作を接続できます。

- **デフォルトでコメントアウト**: ExampleExtensionのヘッダー設定は、sidebarUIおよびchatUIの使用例と同じパターンに合わせてコメントアウトされています。

### 変更内容

| ファイル | 説明 |
|----------|------|
| `lib/registries/headerUIRegistry.ts` | Header UI Registry（HeaderUIConfig、HeaderContentProps、set/use/get/reset） |
| `lib/registries/headerUIRegistry.test.ts` | レジストリユニットテスト（set、merge、reset） |
| `lib/extensions.ts` | ExtensionContextに `ctx.headerUI.configure()` を追加（dispose統合） |
| `lib/extensions.test.ts` | 拡張機能アンロード時のHeaderUIクリーンアップテスト |
| `components/Layout/MainContainer.tsx` | HeaderContentとTitleComponentのために `useHeaderUIConfig()` を使用 |
| `extensions/ExampleExtension/index.ts` | コメントアウト済みヘッダータイトルカスタマイズ例 |
| `extensions/ExampleExtension/headerUI/CustomHeaderTitle.tsx` | カスタムタイトルコンポーネント例 |
| `extensions/README.md` | `ctx.headerUI.configure()` APIのドキュメント |

### ロードマップ更新

| レジストリ | 目的 | ステータス |
|-----------|------|-----------|
| Settings | カスタム設定セクション | ✅ 完了 (PR #23) |
| Chat UI | チャットUIカスタマイズ | ✅ 完了 (PR #32) |
| Sidebar UI | サイドバーカスタマイズ | ✅ 完了 (PR #40) |
| Theme | カスタムカラーテーマ | ✅ 完了 (PR #28) |
| Header UI | ヘッダーカスタマイズ（コンテンツ置換 + タイトルスロット） | ✅ 完了 (このPR) |

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
