### PR TITLE
Add server.json runtime file for orchestration

### DIFF
--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -42,6 +42,7 @@ mcp/                    # MCP 服务器（stdio JSON-RPC，供 AI CLI 使用）
 middleware/             # Token 认证中间件
 process/                # 进程管理器
 relay/                  # HTTP 中继 / 多路复用（NAT 穿透）
+serverinfo/             # 服务器运行时信息（server.json）
 rpc/                    # RPC 消息类型定义
 session/                # Session 存储 + 清理
 settings/               # 设置存储
@@ -95,6 +96,28 @@ if err := json.Unmarshal(data, &parsed); err != nil {
 | `REPOSITORY_TOKEN` | git时 | — | PAT |
 | `GIT_USER_NAME` | git时 | — | commit 用户名 |
 | `GIT_USER_EMAIL` | git时 | — | commit 邮箱 |
+
+## 运行时文件
+
+### server.json
+
+服务器启动时在 `{dataDir}/server.json` 创建，优雅关闭时删除。供编排程序发现运行中的服务器。
+
+```json
+{
+  "pid": 12345,
+  "port": 8080,
+  "started_at": "2025-05-31T10:00:00Z"
+}
+```
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `pid` | int | 服务器进程 ID |
+| `port` | int | 服务器监听端口 |
+| `started_at` | string | 启动时间（RFC3339 格式） |
+
+生命周期：启动时写入 → 运行期间保持 → 优雅关闭时删除
 
 ## 边界
 

--- a/server/main.go
+++ b/server/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pockode/server/mcp"
 	"github.com/pockode/server/middleware"
 	"github.com/pockode/server/relay"
+	"github.com/pockode/server/serverinfo"
 	"github.com/pockode/server/session"
 	"github.com/pockode/server/settings"
 	"github.com/pockode/server/spa"
@@ -167,6 +168,12 @@ func main() {
 		os.Exit(1)
 	}
 	dataDir = absDataDir
+
+	// Write server.json for orchestration programs to discover the running server
+	if err := serverinfo.Write(dataDir, port); err != nil {
+		slog.Error("failed to write server.json", "error", err)
+		os.Exit(1)
+	}
 
 	logger.Init(logger.Config{
 		DataDir: dataDir,
@@ -344,6 +351,9 @@ func main() {
 		worktreeManager.Shutdown()
 		settingsStore.StopWatching()
 		s.StopWatching()
+		if err := serverinfo.Delete(dataDir); err != nil {
+			slog.Error("failed to delete server.json", "error", err)
+		}
 		close(shutdownDone)
 	}()
 

--- a/server/serverinfo/serverinfo.go
+++ b/server/serverinfo/serverinfo.go
@@ -1,0 +1,50 @@
+// Package serverinfo handles the server.json runtime file.
+// This file contains server metadata (PID, port, start time) for orchestration programs.
+package serverinfo
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const filename = "server.json"
+
+// Info represents the server runtime information.
+type Info struct {
+	PID       int    `json:"pid"`
+	Port      int    `json:"port"`
+	StartedAt string `json:"started_at"`
+}
+
+// Write creates the server.json file in the given data directory.
+// Creates the data directory if it doesn't exist.
+func Write(dataDir string, port int) error {
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		return err
+	}
+
+	info := Info{
+		PID:       os.Getpid(),
+		Port:      port,
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	data, err := json.MarshalIndent(info, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filepath.Join(dataDir, filename), data, 0644)
+}
+
+// Delete removes the server.json file from the given data directory.
+// Returns nil if the file doesn't exist.
+func Delete(dataDir string) error {
+	err := os.Remove(filepath.Join(dataDir, filename))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}

--- a/server/serverinfo/serverinfo_test.go
+++ b/server/serverinfo/serverinfo_test.go
@@ -1,0 +1,68 @@
+package serverinfo
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWriteAndDelete(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := Write(dir, 9870); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, filename))
+	if err != nil {
+		t.Fatalf("failed to read server.json: %v", err)
+	}
+
+	var info Info
+	if err := json.Unmarshal(data, &info); err != nil {
+		t.Fatalf("failed to parse server.json: %v", err)
+	}
+
+	if info.Port != 9870 {
+		t.Errorf("Port = %d, want 9870", info.Port)
+	}
+	if info.PID != os.Getpid() {
+		t.Errorf("PID = %d, want %d", info.PID, os.Getpid())
+	}
+	if info.StartedAt == "" {
+		t.Error("StartedAt is empty")
+	}
+	if _, err := time.Parse(time.RFC3339, info.StartedAt); err != nil {
+		t.Errorf("StartedAt is not valid RFC3339: %v", err)
+	}
+
+	if err := Delete(dir); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, filename)); !os.IsNotExist(err) {
+		t.Error("server.json still exists after Delete")
+	}
+}
+
+func TestDeleteNonExistent(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := Delete(dir); err != nil {
+		t.Errorf("Delete on non-existent file should return nil, got: %v", err)
+	}
+}
+
+func TestWriteCreatesDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "dir")
+
+	if err := Write(dir, 8080); err != nil {
+		t.Fatalf("Write failed to create directory: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, filename)); err != nil {
+		t.Errorf("server.json not created: %v", err)
+	}
+}


### PR DESCRIPTION
Create .pockode/server.json on startup with pid, port, and started_at fields for orchestration programs to discover running servers. File is deleted on graceful shutdown.