### PR TITLE
Persist auth token in cluster mode

### DIFF
--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -89,6 +89,15 @@ Uses JSON-RPC 2.0 over WebSocket. All connections must authenticate before calli
 
 Unauthenticated requests receive `"not authenticated"` error and the connection is closed.
 
+### Token Persistence (Frontend)
+
+The cluster frontend persists the auth token to `localStorage` under `cluster_auth_token`. This enables:
+
+- Automatic reconnection on page reload
+- Session continuity without re-entering token
+
+The key differs from main mode (`auth_token`) to avoid conflicts when both modes share the same browser origin.
+
 ### Available Methods
 
 After authentication:

--- a/web-cluster/src/App.tsx
+++ b/web-cluster/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { NodeList } from "./components";
 import { Spinner } from "./components/ui";
+import { authActions, useAuthStore } from "./lib/authStore";
 import { useWSStore } from "./lib/wsStore";
 
 function getTokenFromUrl(): string | null {
@@ -10,7 +11,7 @@ function getTokenFromUrl(): string | null {
 
 export default function App() {
 	const { status, errorMessage, actions, version } = useWSStore();
-	const [token, setToken] = useState<string | null>(null);
+	const token = useAuthStore((state) => state.token);
 	const [tokenInput, setTokenInput] = useState("");
 	const [inputError, setInputError] = useState<string | null>(null);
 
@@ -18,7 +19,7 @@ export default function App() {
 	useEffect(() => {
 		const urlToken = getTokenFromUrl();
 		if (urlToken) {
-			setToken(urlToken);
+			authActions.login(urlToken);
 			// Remove token from URL for security
 			window.history.replaceState({}, "", window.location.pathname);
 		}
@@ -39,7 +40,7 @@ export default function App() {
 			return;
 		}
 		setInputError(null);
-		setToken(trimmed);
+		authActions.login(trimmed);
 	};
 
 	// Show token input if no token
@@ -125,7 +126,8 @@ export default function App() {
 				<button
 					type="button"
 					onClick={() => {
-						setToken(null);
+						actions.disconnect();
+						authActions.logout();
 						setTokenInput("");
 					}}
 					className="mt-4 min-h-[44px] rounded-lg bg-th-accent px-4 py-2 text-sm font-medium text-th-accent-text hover:bg-th-accent-hover"

--- a/web-cluster/src/lib/authStore.ts
+++ b/web-cluster/src/lib/authStore.ts
@@ -1,0 +1,25 @@
+import { create } from "zustand";
+
+const TOKEN_KEY = "cluster_auth_token";
+
+interface AuthState {
+	token: string | null;
+}
+
+export const useAuthStore = create<AuthState>(() => ({
+	token: localStorage.getItem(TOKEN_KEY),
+}));
+
+export const selectHasAuthToken = (state: AuthState) => !!state.token;
+
+export const authActions = {
+	login: (token: string) => {
+		localStorage.setItem(TOKEN_KEY, token);
+		useAuthStore.setState({ token });
+	},
+	logout: () => {
+		localStorage.removeItem(TOKEN_KEY);
+		useAuthStore.setState({ token: null });
+	},
+	getToken: () => useAuthStore.getState().token ?? "",
+};


### PR DESCRIPTION
Add localStorage-based token persistence to match main mode behavior. Token is stored under cluster_auth_token key to avoid conflicts.